### PR TITLE
FIX: FontAwesome 6 compatibility icon upgrade

### DIFF
--- a/app/services/discourse_subscriptions/campaign.rb
+++ b/app/services/discourse_subscriptions/campaign.rb
@@ -91,7 +91,7 @@ module DiscourseSubscriptions
         params = {
           full_name: I18n.t("js.discourse_subscriptions.campaign.supporters"),
           title: I18n.t("js.discourse_subscriptions.campaign.supporter"),
-          flair_icon: "donate",
+          flair_icon: "circle-dollar-to-slot",
         }
 
         group.update(params)


### PR DESCRIPTION
Mitigates `Deprecation notice: The icon name "donate" has been updated to "circle-dollar-to-slot". Please use the new name in your code. Old names will be removed in Q2 2025. [deprecation id: discourse.fontawesome-6-upgrade] [info: https://meta.discourse.org/t/325349]` message.